### PR TITLE
reduces the amount of uvicorn workers to 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,18 @@ FROM python:3.11-slim-bookworm
 
 EXPOSE 3000
 
-WORKDIR /code
+WORKDIR /app
 
-COPY ./requirements.txt /code/requirements.txt
+COPY ./requirements.txt /app/requirements.txt
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip3 install --no-cache-dir --upgrade -r /code/requirements.txt && \
+    pip3 install --no-cache-dir --upgrade -r /app/requirements.txt && \
     apt-get purge -y --auto-remove && \
     rm -rf /var/lib/apt/lists/*
 
-COPY ./lib /code/lib
+COPY ./lib /app/lib
 
-CMD ["gunicorn", "-w 4", "-k", "uvicorn.workers.UvicornWorker", "lib:app", "--log-level", "Debug", "-b", "0.0.0.0:3000", "--timeout", "120"]
+CMD ["gunicorn", "-w 2", "-k", "uvicorn.workers.UvicornWorker", "lib:app", "--log-level", "Debug", "-b", "0.0.0.0:3000", "--timeout", "120"]


### PR DESCRIPTION
Simply reduces the amount of Uvicorn workers to half the current amount.

I have a feeling this might increase performance since we are running a very lightweight app in a very low-capacity machine, which could mean the memory consumed by a single Uvicorn worker could be relatively high.