### PR TITLE
Increase the number of threads to 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update && \
 
 COPY ./lib /app/lib
 
-CMD ["gunicorn", "-w 1", "-k", "uvicorn.workers.UvicornWorker", "lib:app", "--log-level", "Debug", "-b", "0.0.0.0:3000", "--timeout", "120"]
+CMD ["gunicorn", "-w 1", "--threads=2", "-k", "uvicorn.workers.UvicornWorker", "lib:app", "--log-level", "Debug", "-b", "0.0.0.0:3000", "--timeout", "120"]


### PR DESCRIPTION
Following the previous experiment.

We are keeping the number of workers by 1, this increases the number of threads by 2 to improve the maximum concurrent requests.