### PR TITLE
BUG removes lambda support from parachutes

### DIFF
--- a/lib/api.py
+++ b/lib/api.py
@@ -46,7 +46,7 @@ def custom_openapi():
         return app.openapi_schema
     openapi_schema = get_openapi(
         title="RocketPy Infinity-API",
-        version="2.0.0",
+        version="2.1.0",
         description=(
             "<p style='font-size: 18px;'>RocketPy Infinity-API is a RESTful Open API for RocketPy, a rocket flight simulator.</p>"
             "<br/>"

--- a/lib/models/rocket.py
+++ b/lib/models/rocket.py
@@ -21,7 +21,7 @@ class Parachute(BaseModel):
     cd_s: float = 10
     sampling_rate: int = 105
     lag: float = 1.5
-    trigger: Union[str, float] = "lambda p, h, y: y[5] < 0 and h < 800"
+    trigger: Union[str, float] = "apogee"
     noise: Tuple[float, float, float] = (0, 8.3, 0.5)
 
 

--- a/lib/services/rocket.py
+++ b/lib/services/rocket.py
@@ -20,10 +20,6 @@ from lib.services.motor import MotorService
 from lib.views.rocket import RocketSummary
 
 
-class InvalidParachuteTrigger(Exception):
-    """Exception raised for invalid parachute trigger expressions."""
-
-
 class RocketService:
     _rocket: RocketPyRocket
 

--- a/lib/settings/gunicorn.py
+++ b/lib/settings/gunicorn.py
@@ -7,7 +7,7 @@ def post_fork(server, worker):  # pylint: disable=unused-argument
     uptrace.configure_opentelemetry(
         dsn=Secrets.get_secret("UPTRACE_DSN"),
         service_name="infinity-api",
-        service_version="2.0.0",
+        service_version="2.1.0",
         deployment_environment="production",
     )
     from lib.api import (  # pylint: disable=import-outside-toplevel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = {file = ["requirements.txt"]}
 
 [project]
 name = "Infinity-API"
-version = "2.0.0"
+version = "2.1.0"
 description = "RESTFULL open API for rocketpy"
 dynamic = ["dependencies"]
 requires-python = ">=3.12"


### PR DESCRIPTION
As noted by @aasitvora99 , the new rocketpy api does not support lambda expressions for parachute triggers. This hotfix aims to make sure infinity is compliant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated API version to 2.1.0, indicating new specifications.
	- Simplified trigger mechanism in the Parachute class to a static string "apogee".
	- Streamlined validation process for parachute triggers, enhancing safety and readability.

- **Bug Fixes**
	- Removed complex validation logic, improving overall functionality and reducing potential errors.

- **Chores**
	- Updated project version in the configuration files to reflect the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->