### PR TITLE
changes aerodynamic_surfaces.add to add_surfaces

### DIFF
--- a/lib/services/rocket.py
+++ b/lib/services/rocket.py
@@ -61,8 +61,7 @@ class RocketService:
         # NoseCone
         if rocket.nose:
             nose = cls.get_rocketpy_nose(rocket.nose)
-            rocketpy_rocket.aerodynamic_surfaces.add(nose, nose.position)
-            rocketpy_rocket.evaluate_static_margin()
+            rocketpy_rocket.add_surfaces(nose, nose.position)
 
         # FinSet
         if rocket.fins:
@@ -70,16 +69,12 @@ class RocketService:
                 rocket.fins
             )
             for finset in rocketpy_finset_list:
-                rocketpy_rocket.aerodynamic_surfaces.add(
-                    finset, finset.position
-                )
-            rocketpy_rocket.evaluate_static_margin()
+                rocketpy_rocket.add_surfaces(finset, finset.position)
 
         # Tail
         if rocket.tail:
             tail = cls.get_rocketpy_tail(rocket.tail)
-            rocketpy_rocket.aerodynamic_surfaces.add(tail, tail.position)
-            rocketpy_rocket.evaluate_static_margin()
+            rocketpy_rocket.add_surfaces(tail, tail.position)
 
         # Air Brakes
 


### PR DESCRIPTION
rely on rocketpy.rocket.add_surfaces for static margin calculation and aerodynamic surface setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the process of adding aerodynamic surfaces to the rocket model, streamlining functionality.
  
- **Refactor**
	- Consolidated methods for adding aerodynamic surfaces, enhancing efficiency without altering public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->