### PR TITLE
[FIX] Fixes uvloop call for guvicorn worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update && \
 
 COPY ./src /app/src
 
-CMD ["gunicorn", "-c", "src/settings/gunicorn.py", "-w", "1", "--threads=2", "-k", "uvicorn.workers.UvicornWorker", "src.api:app", "--log-level", "Debug", "-b", "0.0.0.0:3000", "--timeout", "60"]
+CMD ["gunicorn", "-c", "src/settings/gunicorn.py", "-w", "1", "--threads=2", "-k", "src.settings.gunicorn.UvloopUvicornWorker", "src.api:app", "--log-level", "Debug", "-b", "0.0.0.0:3000", "--timeout", "60"]

--- a/src/settings/gunicorn.py
+++ b/src/settings/gunicorn.py
@@ -1,5 +1,6 @@
 import uptrace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from uvicorn.workers import UvicornWorker
 from src.secrets import Secrets
 
 
@@ -15,3 +16,7 @@ def post_fork(server, worker):  # pylint: disable=unused-argument
     )
 
     FastAPIInstrumentor.instrument_app(fastapi_server)
+
+
+class UvloopUvicornWorker(UvicornWorker):
+    CONFIG_KWARGS = {"loop": "uvloop"}


### PR DESCRIPTION
This PR fixes the uvloop configuration for the guvicorn worker by introducing a custom subclass that passes the uvloop argument explicitly to the worker configuration.

Added import for UvicornWorker from uvicorn.workers.
Introduced a new subclass UvloopUvicornWorker with an updated uvloop configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the app server’s request handling with an optimized worker implementation for improved concurrency and responsiveness.
	- Introduced a new worker class for better performance in handling requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->