### PR TITLE
BUG: fins failing to accept both sweep and angle

### DIFF
--- a/src/models/sub/aerosurfaces.py
+++ b/src/models/sub/aerosurfaces.py
@@ -42,7 +42,6 @@ class Fins(BaseModel):
         Tuple[List[Tuple[float, float]], Literal['radians', 'degrees']]
     ] = None
     sweep_length: Optional[float] = None
-    sweep_angle: Optional[float] = None
 
     def get_additional_parameters(self):
         return {


### PR DESCRIPTION
Saw an error with fin sweep declaration even after sending `null` value for them. Temp fixing this until lib works on a proper fix.

Stacktrace:
```
2025-10-05 01:24:46,930 - ERROR - get_flight_simulation: Unexpected error Cannot use sweep_length and sweep_angle together
Traceback (most recent call last):
  File "/Infinity-API/src/controllers/interface.py", line 16, in wrapper
    return await method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Infinity-API/src/controllers/flight.py", line 107, in get_flight_simulation
    flight_service = FlightService.from_flight_model(flight.flight)
  File "/Infinity-API/src/services/flight.py", line 34, in from_flight_model
    rocketpy_rocket = RocketService.from_rocket_model(flight.rocket).rocket
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Infinity-API/src/services/rocket.py", line 69, in from_rocket_model
    rocketpy_finset_list = cls.get_rocketpy_finset_list_from_fins_list(
        rocket.fins
    )
  File "/Infinity-API/src/services/rocket.py", line 150, in get_rocketpy_finset_list_from_fins_list
    cls.get_rocketpy_finset(fins, fins.fins_kind) for fins in fins_list
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Infinity-API/src/services/rocket.py", line 164, in get_rocketpy_finset
    rocketpy_finset = RocketPyTrapezoidalFins(
        n=fins.n,
    ...<3 lines>...
        **fins.get_additional_parameters(),
    )
  File "/RocketPy/rocketpy/rocket/aero_surface/fins/trapezoidal_fins.py", line 174, in __init__
    raise ValueError("Cannot use sweep_length and sweep_angle together")
ValueError: Cannot use sweep_length and sweep_angle together
```