### PR TITLE
feat(flight): KML trajectory export endpoint

### DIFF
--- a/src/controllers/flight.py
+++ b/src/controllers/flight.py
@@ -146,6 +146,28 @@ class FlightController(ControllerBase):
         return flight_service.get_flight_rpy()
 
     @controller_exception_handler
+    async def get_flight_kml(
+        self,
+        flight_id: str,
+    ) -> bytes:
+        """
+        Get the flight trajectory as a KML file.
+
+        Args:
+            flight_id: str
+
+        Returns:
+            bytes (KML XML)
+
+        Raises:
+            HTTP 404 Not Found: If the flight is not found
+                in the database.
+        """
+        flight = await self.get_flight_by_id(flight_id)
+        flight_service = FlightService.from_flight_model(flight.flight)
+        return flight_service.get_flight_kml()
+
+    @controller_exception_handler
     async def get_flight_simulation(
         self,
         flight_id: str,

--- a/src/routes/flight.py
+++ b/src/routes/flight.py
@@ -301,6 +301,42 @@ async def update_flight_rocket(
         )
 
 
+@router.get(
+    "/{flight_id}/kml",
+    responses={
+        200: {
+            "description": "KML trajectory file download",
+            "content": {"application/vnd.google-earth.kml+xml": {}},
+        }
+    },
+    status_code=200,
+    response_class=Response,
+)
+async def get_flight_kml(
+    flight_id: str,
+    controller: FlightControllerDep,
+):
+    """
+    Export a flight trajectory as a KML file for Google Earth.
+
+    ## Args
+    ``` flight_id: str ```
+    """
+    with tracer.start_as_current_span("get_flight_kml"):
+        kml = await controller.get_flight_kml(flight_id)
+        headers = {
+            "Content-Disposition": (
+                f'attachment; filename="flight_{flight_id}.kml"'
+            ),
+        }
+        return Response(
+            content=kml,
+            headers=headers,
+            media_type="application/vnd.google-earth.kml+xml",
+            status_code=200,
+        )
+
+
 @router.get("/{flight_id}/simulate")
 async def get_flight_simulation(
     flight_id: str,

--- a/src/services/flight.py
+++ b/src/services/flight.py
@@ -1,9 +1,12 @@
 import json
+import os
+import tempfile
 from typing import Self, Tuple
 
 import numpy as np
 
 from rocketpy.simulation.flight import Flight as RocketPyFlight
+from rocketpy.simulation.flight_data_exporter import FlightDataExporter
 from rocketpy._encoders import RocketPyEncoder, RocketPyDecoder
 from rocketpy.mathutils.function import Function
 from rocketpy.motors.solid_motor import SolidMotor
@@ -498,6 +501,25 @@ class FlightService:
         )
         flight_simulation = FlightSimulation(**encoded_attributes)
         return flight_simulation
+
+    def get_flight_kml(self) -> bytes:
+        """
+        Get the flight trajectory as a KML file for Google Earth.
+
+        Returns:
+            bytes (UTF-8 encoded KML)
+        """
+        with tempfile.NamedTemporaryFile(
+            suffix=".kml", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+        try:
+            FlightDataExporter(self._flight).export_kml(file_name=tmp_path)
+            with open(tmp_path, "rb") as fh:
+                return fh.read()
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
 
     def get_flight_rpy(self) -> bytes:
         """

--- a/src/services/flight.py
+++ b/src/services/flight.py
@@ -514,7 +514,7 @@ class FlightService:
         ) as tmp:
             tmp_path = tmp.name
         try:
-            FlightDataExporter(self._flight).export_kml(file_name=tmp_path)
+            FlightDataExporter(self.flight).export_kml(file_name=tmp_path)
             with open(tmp_path, "rb") as fh:
                 return fh.read()
         finally:

--- a/tests/unit/test_routes/test_flights_route.py
+++ b/tests/unit/test_routes/test_flights_route.py
@@ -57,6 +57,7 @@ def mock_controller_instance():
         mock_controller.get_rocketpy_flight_rpy = AsyncMock()
         mock_controller.import_flight_from_rpy = AsyncMock()
         mock_controller.get_flight_notebook = AsyncMock()
+        mock_controller.get_flight_kml = AsyncMock()
         mock_controller.update_environment_by_flight_id = AsyncMock()
         mock_controller.update_rocket_by_flight_id = AsyncMock()
         mock_controller.create_flight_from_references = AsyncMock()
@@ -535,6 +536,38 @@ def test_read_rocketpy_flight_rpy_server_error(mock_controller_instance):
         HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
     )
     response = client.get('/flights/123/rocketpy')
+    assert response.status_code == 500
+    assert response.json() == {'detail': 'Internal Server Error'}
+
+
+def test_read_flight_kml(mock_controller_instance):
+    kml_bytes = b'<?xml version="1.0" encoding="UTF-8"?><kml></kml>'
+    mock_controller_instance.get_flight_kml = AsyncMock(return_value=kml_bytes)
+    response = client.get('/flights/123/kml')
+    assert response.status_code == 200
+    assert response.content == kml_bytes
+    assert (
+        response.headers['content-type']
+        == 'application/vnd.google-earth.kml+xml'
+    )
+    assert 'flight_123.kml' in response.headers['content-disposition']
+    mock_controller_instance.get_flight_kml.assert_called_once_with('123')
+
+
+def test_read_flight_kml_not_found(mock_controller_instance):
+    mock_controller_instance.get_flight_kml.side_effect = HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND
+    )
+    response = client.get('/flights/123/kml')
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'Not Found'}
+
+
+def test_read_flight_kml_server_error(mock_controller_instance):
+    mock_controller_instance.get_flight_kml.side_effect = HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+    )
+    response = client.get('/flights/123/kml')
     assert response.status_code == 500
     assert response.json() == {'detail': 'Internal Server Error'}
 

--- a/tests/unit/test_routes/test_motors_route.py
+++ b/tests/unit/test_routes/test_motors_route.py
@@ -249,7 +249,7 @@ def test_create_liquid_motor_sampled_density(
 
 
 def test_create_motor_invalid_geometry_kind(
-    stub_motor_dump, stub_tank_dump, mock_controller_instance
+    stub_motor_dump, stub_tank_dump
 ):
     stub_tank_dump['geometry'] = {
         'geometry_kind': 'pyramid',
@@ -263,7 +263,7 @@ def test_create_motor_invalid_geometry_kind(
 
 
 def test_create_motor_mass_kind_missing_fields(
-    stub_motor_dump, stub_tank_dump, mock_controller_instance
+    stub_motor_dump, stub_tank_dump
 ):
     # stub_tank_dump defaults to MASS_FLOW with all required fields
     # populated; switching to MASS without adding liquid_mass/gas_mass
@@ -280,7 +280,7 @@ def test_create_motor_mass_kind_missing_fields(
 
 
 def test_create_motor_level_kind_missing_liquid_height(
-    stub_motor_dump, stub_tank_dump, mock_controller_instance
+    stub_motor_dump, stub_tank_dump
 ):
     stub_tank_dump['tank_kind'] = 'LEVEL'
     stub_motor_dump.update(
@@ -292,7 +292,7 @@ def test_create_motor_level_kind_missing_liquid_height(
 
 
 def test_create_motor_ullage_kind_missing_ullage(
-    stub_motor_dump, stub_tank_dump, mock_controller_instance
+    stub_motor_dump, stub_tank_dump
 ):
     stub_tank_dump['tank_kind'] = 'ULLAGE'
     stub_motor_dump.update(
@@ -304,7 +304,7 @@ def test_create_motor_ullage_kind_missing_ullage(
 
 
 def test_create_motor_mass_flow_kind_missing_flow_rates(
-    stub_motor_dump, mock_controller_instance
+    stub_motor_dump
 ):
     # Build a tank payload with MASS_FLOW kind but no flow-rate fields
     # so the guard rejects it.


### PR DESCRIPTION
GET /flights/{id}/kml returns a KML file of the flight trajectory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to export a flight trajectory as a Google Earth KML file.
  * KML downloads include the appropriate file type and a flight-specific filename.

* **Bug Fixes**
  * Improved handling of missing flights and unexpected errors during KML export.

* **Tests**
  * Added coverage for successful KML downloads, not-found responses, and server errors.
  * Updated motor validation tests for more focused request checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->